### PR TITLE
pypdf 6.8.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.5.0" %}
+{% set version = "6.8.0" %}
 
 package:
   name: pypdf-split
@@ -7,10 +7,10 @@ package:
 source:
   - folder: dist
     url: https://pypi.io/packages/source/p/pypdf/pypdf-{{ version }}.tar.gz
-    sha256: 9e78950906380ae4f2ce1d9039e9008098ba6366a4d9c7423c4bdbd6e6683404
+    sha256: cb7eaeaa4133ce76f762184069a854e03f4d9a08568f0e0623f7ea810407833b
   - folder: src
     url: https://github.com/py-pdf/pypdf/archive/refs/tags/{{ version }}.tar.gz
-    sha256: d8a744c7a696472d54b476eea26ce49e61caacd65b5c72680104e271b8cd4f64
+    sha256: fd86950620d59e9b8580355321a394e93488b2951725e1c38d26d2061a20dd2b
 
 build:
   number: 0


### PR DESCRIPTION
pypdf 6.8.0 

**Destination channel:** Defaults

### Links

- [PKG-12968]
- dev_url:        https://github.com/py-pdf/pypdf/tree/6.8.0
- conda_forge:    https://github.com/conda-forge/pypdf-feedstock
- pypi:           https://pypi.org/project/pypdf/6.8.0
- pypi inspector: https://inspector.pypi.io/project/pypdf/6.8.0

### Explanation of changes:

- new version number

CVE-2026-31826 - medium
CVE-2026-24688 - medium
CVE-2026-27628 - low
CVE-2026-28804 - medium

[PKG-12968]: https://anaconda.atlassian.net/browse/PKG-12968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ